### PR TITLE
Add authenticated versions of functions in Repos.Commits

### DIFF
--- a/Github/Data.hs
+++ b/Github/Data.hs
@@ -11,7 +11,7 @@ import Control.Applicative
 import Control.Monad
 import qualified Data.Text as T
 import Data.Aeson.Types
-import System.Locale (defaultTimeLocale)
+import Data.Time (defaultTimeLocale)
 import qualified Data.Vector as V
 import qualified Data.HashMap.Lazy as Map
 import Data.Hashable (Hashable)

--- a/Github/Data/Definitions.hs
+++ b/Github/Data/Definitions.hs
@@ -7,6 +7,14 @@ import Data.Data
 import qualified Control.Exception as E
 import qualified Data.Map as M
 
+-- | The options for querying commits.
+data CommitQueryOption = CommitQuerySha String
+                       | CommitQueryPath String
+                       | CommitQueryAuthor String
+                       | CommitQuerySince GithubDate
+                       | CommitQueryUntil GithubDate
+                       deriving (Show, Eq, Ord)
+
 -- | Errors have been tagged according to their source, so you can more easily
 -- dispatch and handle them.
 data Error =

--- a/Github/Issues.hs
+++ b/Github/Issues.hs
@@ -17,8 +17,8 @@ import Github.Data
 import Github.Private
 import Data.List (intercalate)
 import Data.Time.Format (formatTime)
-import System.Locale (defaultTimeLocale)
 import Data.Time.Clock (UTCTime(..))
+import Data.Time (defaultTimeLocale)
 
 -- | A data structure for describing how to filter issues. This is used by
 -- @issuesForRepo@.

--- a/Github/Repos/Commits.hs
+++ b/Github/Repos/Commits.hs
@@ -2,11 +2,17 @@
 -- <http://developer.github.com/v3/repos/commits/>.
 module Github.Repos.Commits (
  commitsFor
+,commitsFor'
 ,commit
+,commit'
 ,commentsFor
+,commentsFor'
 ,commitCommentsFor
+,commitCommentsFor'
 ,commitCommentFor
+,commitCommentFor'
 ,diff
+,diff'
 ,module Github.Data
 ) where
 
@@ -17,37 +23,78 @@ import Github.Private
 --
 -- > commitsFor "mike-burns" "github"
 commitsFor :: String -> String -> IO (Either Error [Commit])
-commitsFor user repo = githubGet ["repos", user, repo, "commits"]
+commitsFor = commitsFor' Nothing
+
+-- | The commit history for a repo.
+-- With authentication.
+--
+-- > commitsFor' (Just (GithubBasicAuth (user, password))) "mike-burns" "github"
+commitsFor' :: Maybe GithubAuth -> String -> String -> IO (Either Error [Commit])
+commitsFor' auth user repo = githubGet' auth ["repos", user, repo, "commits"]
 
 -- | Details on a specific SHA1 for a repo.
 --
 -- > commit "mike-burns" "github" "9d1a9a361266c3c890b1108ad2fdf52f824b1b81"
 commit :: String -> String -> String -> IO (Either Error Commit)
-commit user repo sha1 = githubGet ["repos", user, repo, "commits", sha1]
+commit = commit' Nothing
+
+-- | Details on a specific SHA1 for a repo.
+-- With authentication.
+--
+-- > commit (Just $ GithubBasicAuth (username, password)) "mike-burns" "github" "9d1a9a361266c3c890b1108ad2fdf52f824b1b81"
+commit' :: Maybe GithubAuth -> String -> String -> String -> IO (Either Error Commit)
+commit' auth user repo sha1 = githubGet' auth ["repos", user, repo, "commits", sha1]
+
 
 -- | All the comments on a Github repo.
 --
 -- > commentsFor "thoughtbot" "paperclip"
 commentsFor :: String -> String -> IO (Either Error [Comment])
-commentsFor user repo = githubGet ["repos", user, repo, "comments"]
+commentsFor = commentsFor' Nothing
+
+-- | All the comments on a Github repo.
+-- With authentication.
+--
+-- > commentsFor "thoughtbot" "paperclip"
+commentsFor' :: Maybe GithubAuth -> String -> String -> IO (Either Error [Comment])
+commentsFor' auth user repo = githubGet' auth ["repos", user, repo, "comments"]
 
 -- | Just the comments on a specific SHA for a given Github repo.
 --
 -- > commitCommentsFor "thoughtbot" "paperclip" "41f685f6e01396936bb8cd98e7cca517e2c7d96b"
 commitCommentsFor :: String -> String -> String -> IO (Either Error [Comment])
-commitCommentsFor user repo sha1 =
-  githubGet ["repos", user, repo, "commits", sha1, "comments"]
+commitCommentsFor = commitCommentsFor' Nothing
+
+-- | Just the comments on a specific SHA for a given Github repo.
+-- With authentication.
+--
+-- > commitCommentsFor "thoughtbot" "paperclip" "41f685f6e01396936bb8cd98e7cca517e2c7d96b"
+commitCommentsFor' :: Maybe GithubAuth -> String -> String -> String -> IO (Either Error [Comment])
+commitCommentsFor' auth user repo sha1 =
+  githubGet' auth ["repos", user, repo, "commits", sha1, "comments"]
 
 -- | A comment, by its ID, relative to the Github repo.
 --
 -- > commitCommentFor "thoughtbot" "paperclip" "669575"
 commitCommentFor :: String -> String -> String -> IO (Either Error Comment)
-commitCommentFor user repo reqCommentId =
-  githubGet ["repos", user, repo, "comments", reqCommentId]
+commitCommentFor = commitCommentFor' Nothing
+
+-- | A comment, by its ID, relative to the Github repo.
+--
+-- > commitCommentFor "thoughtbot" "paperclip" "669575"
+commitCommentFor' :: Maybe GithubAuth -> String -> String -> String -> IO (Either Error Comment)
+commitCommentFor' auth user repo reqCommentId =
+  githubGet' auth ["repos", user, repo, "comments", reqCommentId]
 
 -- | The diff between two treeishes on a repo.
 --
 -- > diff "thoughtbot" "paperclip" "41f685f6e01396936bb8cd98e7cca517e2c7d96b" "HEAD"
 diff :: String -> String -> String -> String -> IO (Either Error Diff)
-diff user repo base headref =
-  githubGet ["repos", user, repo, "compare", base ++ "..." ++ headref]
+diff = diff' Nothing
+
+-- | The diff between two treeishes on a repo.
+--
+-- > diff "thoughtbot" "paperclip" "41f685f6e01396936bb8cd98e7cca517e2c7d96b" "HEAD"
+diff' :: Maybe GithubAuth -> String -> String -> String -> String -> IO (Either Error Diff)
+diff' auth user repo base headref =
+  githubGet' auth ["repos", user, repo, "compare", base ++ "..." ++ headref]

--- a/github.cabal
+++ b/github.cabal
@@ -154,7 +154,7 @@ Library
 
   -- Packages needed in order to build this package.
   Build-depends: base >= 4.0 && < 5.0,
-                 time,
+                 time >=1.5 && <1.6,
                  aeson >= 0.6.1.0,
                  attoparsec >= 0.10.3.0,
                  bytestring,


### PR DESCRIPTION
It is now possible to make authenticated requests for all the functions in Github.Repos.Commits. All changes are backwards-compatible, as this merely adds more functionality.