### PR TITLE
Add initial hspec test

### DIFF
--- a/github.cabal
+++ b/github.cabal
@@ -183,3 +183,35 @@ Library
   -- Build-tools:
 
   GHC-Options: -Wall -fno-warn-orphans
+
+
+test-suite github-test
+  type: exitcode-stdio-1.0
+  hs-source-dirs: spec, .
+  main-is: Spec.hs
+  build-depends: base >= 4.0 && < 5.0,
+                 time,
+                 aeson >= 0.6.1.0,
+                 attoparsec >= 0.10.3.0,
+                 bytestring,
+                 case-insensitive >= 0.4.0.4,
+                 containers,
+                 hashable,
+                 text,
+                 old-locale,
+                 HTTP,
+                 network,
+                 http-conduit >= 1.8,
+                 conduit,
+                 failure,
+                 http-types,
+                 data-default,
+                 vector,
+                 unordered-containers >= 0.2 && < 0.3,
+                 cryptohash >= 0.11,
+                 byteable >= 0.1.0,
+                 base16-bytestring >= 0.1.1.6
+
+                 , hspec
+
+  ghc-options: -Wall -fno-warn-orphans

--- a/spec/Github/UsersSpec.hs
+++ b/spec/Github/UsersSpec.hs
@@ -1,0 +1,17 @@
+module Github.UsersSpec where
+
+import Github.Users (userInfoFor)
+import Github.Data.Definitions (DetailedOwner(..))
+
+import Test.Hspec (it, describe, shouldBe, Spec)
+
+fromRight :: Either a b -> b
+fromRight (Right b) = b
+fromRight (Left _) = error "Expected a Right and got a Left"
+
+spec :: Spec
+spec =
+  describe "userInfoFor" $ do
+    it "returns information about the user" $ do
+      userInfo <- userInfoFor "mike-burns"
+      detailedOwnerLogin (fromRight userInfo) `shouldBe` "mike-burns"

--- a/spec/Spec.hs
+++ b/spec/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
Hi @jwiegley,

Thanks very much for creating this library. 

We're starting to use it for a project and we'd like to add code for some missing endpoints. With our additions, we'd really like to be able to add automated tests, so it would be helpful to have some kind of a pattern for this in place. In this commit I'm basically just turning one of the examples into integration spec using hspec. Going forward, we could separate integration from unit tests that don't do HTTP requests, perhaps something along the lines of [the twitter-conduit library](https://github.com/himura/twitter-conduit/blob/master/tests/ApiSpec.hs#L23:L28).

Any thoughts on this pattern, or is there another way you'd prefer to implement automated testing?

Thanks again for creating this helpful library!

Justin