### PR TITLE
Fix data declarations for Content results

### DIFF
--- a/Github/Data.hs
+++ b/Github/Data.hs
@@ -674,19 +674,34 @@ instance FromJSON Content where
   parseJSON (Array os) = ContentDirectory <$> (mapM parseJSON $ V.toList os)
   parseJSON _ = fail "Could not build a Content"
 
-instance FromJSON ContentData where
+instance FromJSON ContentFileData where
   parseJSON (Object o) =
-    ContentData <$> o .: "type"
-                <*> o .: "encoding"
-                <*> o .: "size"
-                <*> o .: "name"
+    ContentFileData <$> parseJSON (Object o)
+                    <*> o .: "encoding"
+                    <*> o .: "size"
+                    <*> o .: "content"
+  parseJSON _ = fail "Could not build a ContentFileData"
+
+instance FromJSON ContentItem where
+  parseJSON (Object o) =
+    ContentItem <$> o .: "type"
+                <*> parseJSON (Object o)
+  parseJSON _ = fail "Could not build a ContentItem"
+
+instance FromJSON ContentItemType where
+  parseJSON (String "file") = return ItemFile
+  parseJSON (String "dir")  = return ItemDir
+  parseJSON _ = fail "Could not build a ContentItemType"
+
+instance FromJSON ContentInfo where
+  parseJSON (Object o) =
+    ContentInfo <$> o .: "name"
                 <*> o .: "path"
-                <*> o .: "content"
                 <*> o .: "sha"
                 <*> o .: "url"
                 <*> o .: "git_url"
                 <*> o .: "html_url"
-  parseJSON _ = fail "Could not build a ContentData"
+  parseJSON _ = fail "Could not build a ContentInfo"
 
 -- | A slightly more generic version of Aeson's @(.:?)@, using `mzero' instead
 -- of `Nothing'.

--- a/Github/Data/Definitions.hs
+++ b/Github/Data/Definitions.hs
@@ -461,16 +461,31 @@ data Code = Code {
   ,codeRepo :: Repo
 } deriving (Show, Data, Typeable, Eq, Ord)
 
-data Content = ContentFile ContentData | ContentDirectory [ContentData]
+data Content
+  = ContentFile ContentFileData
+  | ContentDirectory [ContentItem]
  deriving (Show, Data, Typeable, Eq, Ord)
 
-data ContentData = ContentData {
-   contentType :: String
-  ,contentEncoding :: String
-  ,contentSize :: Int
-  ,contentName :: String
+data ContentFileData = ContentFileData {
+   contentFileInfo :: ContentInfo
+  ,contentFileEncoding :: String
+  ,contentFileSize :: Int
+  ,contentFileContent :: String
+} deriving (Show, Data, Typeable, Eq, Ord)
+
+-- | An item in a directory listing.
+data ContentItem = ContentItem {
+   contentItemType :: ContentItemType
+  ,contentItemInfo :: ContentInfo
+} deriving (Show, Data, Typeable, Eq, Ord)
+
+data ContentItemType = ItemFile | ItemDir
+  deriving (Show, Data, Typeable, Eq, Ord)
+
+-- | Information common to both kinds of Content: files and directories.
+data ContentInfo = ContentInfo {
+   contentName :: String
   ,contentPath :: String
-  ,contentData :: String
   ,contentSha :: String
   ,contentUrl :: String
   ,contentGitUrl :: String

--- a/samples/Repos/Contents.hs
+++ b/samples/Repos/Contents.hs
@@ -1,0 +1,46 @@
+module GetContents where
+
+import qualified Github.Repos as Github
+import Data.List
+import Prelude hiding (truncate, getContents)
+
+main = do
+  putStrLn "Root"
+  putStrLn "===="
+  getContents ""
+
+  putStrLn "LICENSE"
+  putStrLn "======="
+  getContents "LICENSE"
+
+getContents path = do
+  contents <- Github.contentsFor "mike-burns" "ohlaunch" path Nothing
+  putStrLn $ either (("Error: " ++) . show) formatContents contents
+
+formatContents (Github.ContentFile fileData) =
+  formatContentInfo (Github.contentFileInfo fileData) ++
+  unlines
+    [ show (Github.contentFileSize fileData) ++ " bytes"
+    , "encoding: " ++ Github.contentFileEncoding fileData
+    , "data: " ++ truncate (Github.contentFileContent fileData)
+    ]
+
+formatContents (Github.ContentDirectory items) =
+  intercalate "\n\n" $ map formatItem items
+
+formatContentInfo contentInfo =
+  unlines
+    [ "name: " ++ Github.contentName contentInfo
+    , "path: " ++ Github.contentPath contentInfo
+    , "sha: " ++ Github.contentSha contentInfo
+    , "url: " ++ Github.contentUrl contentInfo
+    , "git url: " ++ Github.contentGitUrl contentInfo
+    , "html url: " ++ Github.contentHtmlUrl contentInfo
+    ]
+
+formatItem item =
+   "type: " ++ show (Github.contentItemType item) ++ "\n" ++
+  formatContentInfo (Github.contentItemInfo item)
+
+
+truncate str = take 40 str ++ "... (truncated)"


### PR DESCRIPTION
Previously, the declarations made the assumption that every
`ContentData` has an encoding, size, and data. However, only files (not
directories) have this information. Additionally, you only get this
additional file information when you specifically request a file; not
when a file is in a directory listing from getting the contents of a
directory.

Having read the GitHub api docs, it seems there are three types of
things we want to differentiate:

* When you get the contents of a file - those contents
* When you get the contents of a directory - a file which is in that
  directory
* When you get the contents of a directory - a subdirectory

This commit fixes the data declarations to align better with the API.
It adds a few new types:

* ContentInfo, which is common to all three of the above things
* ContentFileData, the first one
* ContentItem, which covers the second and third
* ContentItemType, which allows you to tell the difference between
  the second and third

It also removes ContentData, which is subsumed by these new types.

I've tested all three cases in the REPL (on a public repo only) and
this appears to work. Updates to samples are soon to come.