### PR TITLE
Get a repo README

### DIFF
--- a/Github/Repos.hs
+++ b/Github/Repos.hs
@@ -25,6 +25,8 @@ module Github.Repos (
 ,branchesFor'
 ,contentsFor
 ,contentsFor'
+,readmeFor
+,readmeFor'
 ,module Github.Data
 ,RepoPublicity(..)
 
@@ -220,6 +222,21 @@ contentsFor' auth userName reqRepoName reqContentPath ref =
   ["repos", userName, reqRepoName, "contents", reqContentPath] $
   maybe "" ("ref="++) ref
 
+-- | The contents of a README file in a repo, given the repo owner and name
+--
+-- > readmeFor "thoughtbot" "paperclip"
+readmeFor :: String -> String -> IO (Either Error Content)
+readmeFor = readmeFor' Nothing
+
+-- | The contents of a README file in a repo, given the repo owner and name
+-- With Authentication
+--
+-- > readmeFor' (Just (GithubBasicAuth (user, password))) "thoughtbot" "paperclip"
+readmeFor' :: Maybe GithubAuth -> String -> String -> IO (Either Error Content)
+readmeFor' auth userName reqRepoName =
+  githubGetWithQueryString' auth
+  ["repos", userName, reqRepoName, "readme"] $
+  ""
 
 data NewRepo = NewRepo {
   newRepoName         :: String

--- a/samples/Repos/GetReadme.hs
+++ b/samples/Repos/GetReadme.hs
@@ -1,0 +1,11 @@
+module GetReadme where
+
+import qualified Github.Repos as Github
+import Data.List
+import Data.Maybe
+
+main = do
+  possibleReadme <- Github.readmeFor "jwiegley" "github"
+  case possibleReadme of
+       (Left error) -> putStrLn $ "Error: " ++ (show error)
+       (Right (Github.ContentFile cd)) -> putStrLn $ (show cd)


### PR DESCRIPTION
Adds function and sample for using the GitHub API to get a repo's README (nice because it detects various README formats)