### PR TITLE
Add issueCommentHtmlUrl field to IssueComment

### DIFF
--- a/Github/Data.hs
+++ b/Github/Data.hs
@@ -286,6 +286,7 @@ instance FromJSON IssueComment where
     IssueComment <$> o .: "updated_at"
                  <*> o .: "user"
                  <*> o .: "url"
+                 <*> o .: "html_url"
                  <*> o .: "created_at"
                  <*> o .: "body"
                  <*> o .: "id"

--- a/Github/Data/Definitions.hs
+++ b/Github/Data/Definitions.hs
@@ -258,6 +258,7 @@ data IssueComment = IssueComment {
    issueCommentUpdatedAt :: GithubDate
   ,issueCommentUser :: GithubOwner
   ,issueCommentUrl :: String
+  ,issueCommentHtmlUrl :: String
   ,issueCommentCreatedAt :: GithubDate
   ,issueCommentBody :: String
   ,issueCommentId :: Int


### PR DESCRIPTION
The issue structure that is returned by GitHub API calls includes an `html_url` field (e.g. https://developer.github.com/v3/issues/#list-issues). This PR adds this field to the `IssueComment` record type.