### PR TITLE
expose Github.Private

### DIFF
--- a/Github/Private.hs
+++ b/Github/Private.hs
@@ -1,5 +1,13 @@
 {-# LANGUAGE OverloadedStrings, StandaloneDeriving, DeriveDataTypeable #-}
 {-# LANGUAGE CPP, FlexibleContexts #-}
+
+-- | This module is /private/. It is exposed to facilitate customization
+-- and extension of the /public/ API of this package without explicitely
+-- forking the package.
+--
+-- This module is not part of the /public/ API and as such changes in this
+-- module may not be reflected in the version of the package.
+--
 module Github.Private where
 
 import Github.Data

--- a/github.cabal
+++ b/github.cabal
@@ -153,6 +153,9 @@ Library
                    Github.Users.Followers
                    Github.Search
 
+                   -- Private
+                   Github.Private
+
   -- Packages needed in order to build this package.
   Build-depends: base >= 4.0 && < 5.0,
                  time,
@@ -176,9 +179,6 @@ Library
                  cryptohash >= 0.11,
                  byteable >= 0.1.0,
                  base16-bytestring >= 0.1.1.6
-
-  -- Modules not exported by this package.
-  Other-modules:       Github.Private
 
   -- Extra tools (e.g. alex, hsc2hs, ...) needed to build the source.
   -- Build-tools:


### PR DESCRIPTION
This PR depends on personal preferences about package API design, so I am aware that it may be rejected.

## Concrete Motivation

I am writing an application that migrates data from GitHub to GitLab. I found that the Haskell bindings are not exposing some functionality of the GitHub that could be easily implemented if the functions of the module `Github.Private` would be available. This would allow me to already release the tool while waiting for the respective changes to be integrated in a new release of the github package on Hackage. Once those change are released I would make a new version of my package that doesn't depend on `Github.Private` any more. In case the customization that I need are too specialized to be integrated upstream in the github package, I wouldn't have to fork that package but could just extend it.

## More General Notes

When writing applications I often find the need to extend or customize the APIs of existing packages. 

Sometimes those extension and customization are general enough in order to submit them as PRs upstream, but it often takes some time until a new version with the changes shows up on Hackage.

Sometimes those extensions and customizations are rather specific and it wouldn't make sense to include them in the API of the package.

In both cases it helps if packages expose more low-level or *internal* APIs along with the high-level *public* APIs. By explicitly marking parts of the API *internal* users of those parts are aware that they can't expect the same (or any) guarantees regarding the stability as for the *public* API. So those parts can change at any time without warning or being reflected in the package version. Yet there are situations where maintainers of packages that consume those *private* APIs are willing and able to deal with this (often just as a transitional state).