### PR TITLE
Retrieve detailed info about a user without specifying a username

### DIFF
--- a/Github/Users.hs
+++ b/Github/Users.hs
@@ -3,6 +3,7 @@
 module Github.Users (
  userInfoFor
 ,userInfoFor'
+,userInfoCurrent'
 ,module Github.Data
 ) where
 
@@ -21,3 +22,9 @@ userInfoFor' auth userName = githubGet' auth ["users", userName]
 -- > userInfoFor "mike-burns"
 userInfoFor :: String -> IO (Either Error DetailedOwner)
 userInfoFor = userInfoFor' Nothing
+
+-- | Retrieve information about the user associated with the supplied authentication.
+--
+-- > userInfoCurrent' (GithubOAuth "...")
+userInfoCurrent' :: Maybe GithubAuth -> IO (Either Error DetailedOwner)
+userInfoCurrent' auth = githubGet' auth ["user"]


### PR DESCRIPTION
Hi jwiegley,

This PR simply adds the ability to retrieve DetailedUser information about a user by relying on the GithubAuth instead of specifying a username. I need this for example, when authenticating a new user with OAuth2. All I get back is the access_token. So I need to query /user in order to obtain user info.

Thanks!