### PR TITLE
Compile warning free

### DIFF
--- a/Github/Data.hs
+++ b/Github/Data.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP, DeriveDataTypeable, OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | This module re-exports the @Github.Data.Definitions@ module, adding
 -- instances of @FromJSON@ to it. If you wish to use the data without the
@@ -13,7 +14,9 @@ module Github.Data (
   module Github.Data.Teams,
   ) where
 
+#if !MIN_VERSION_base(4,8,0)
 import Control.Applicative
+#endif
 import Control.Monad
 import qualified Data.Text as T
 import Data.Aeson.Compat
@@ -38,9 +41,15 @@ import Github.Data.Teams
 
 instance FromJSON GithubDate where
   parseJSON (String t) =
-    case parseTime defaultTimeLocale "%FT%T%Z" (T.unpack t) of
+    case pt defaultTimeLocale "%FT%T%Z" (T.unpack t) of
          Just d -> pure $ GithubDate d
          _      -> fail "could not parse Github datetime"
+    where
+#if MIN_VERSION_time(1,5,0)
+      pt = parseTimeM True
+#else
+      pt = parseTime
+#endif
   parseJSON _          = fail "Given something besides a String"
 
 instance FromJSON Commit where

--- a/Github/Repos/Webhooks/Validate.hs
+++ b/Github/Repos/Webhooks/Validate.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | Verification of incomming webhook payloads, as described at
@@ -7,7 +8,9 @@ module Github.Repos.Webhooks.Validate (
   isValidPayload
 ) where
 
+#if !MIN_VERSION_base(4,8,0)
 import Control.Applicative
+#endif
 import Crypto.Hash
 import qualified Data.ByteString.Char8 as BS
 import Data.Byteable (constEqBytes, toBytes)

--- a/github.cabal
+++ b/github.cabal
@@ -191,6 +191,7 @@ Library
                  text,
                  old-locale,
                  http-conduit >= 1.8,
+                 http-client,
                  http-types,
                  data-default,
                  vector,


### PR DESCRIPTION
One option is to use `base-compat`
Also is there reason why `http-conduit` is used, and not `http-client` ?